### PR TITLE
[WIP] maint: add legacy_mode_v2 flag for default fixes

### DIFF
--- a/hnn_core/drives.py
+++ b/hnn_core/drives.py
@@ -155,7 +155,10 @@ def _check_poisson_rates(rate_constant, target_populations, all_cell_types):
 
 def _add_drives_from_params(net):
     drive_specs = _extract_drive_specs_from_hnn_params(
-        net._params, list(net.cell_types.keys()), net._legacy_mode
+        net._params,
+        list(net.cell_types.keys()),
+        net._legacy_mode,
+        net._legacy_mode_v2,
     )
     bias_specs = _extract_bias_specs_from_hnn_params(
         net._params, list(net.cell_types.keys())
@@ -236,12 +239,11 @@ def _add_drives_from_params(net):
         _tstop = bias_specs["tonic"][cellname]["tstop"]
         net.add_tonic_bias(amplitude=_cell_types_amplitudes, t0=_t0, tstop=_tstop)
 
-    # KD 11/03: this is a problem for reproducibility in HNN core, as this is only done when loading params from .json files,
-    # so the seeds between the original simulation and loaded simulation will differ. Do we need this?
-    # # in HNN-GUI, seed is determined by "absolute GID" instead of the
-    # # gid offset with respect to the first cell of a population.
-    # for drive_name, drive in net.external_drives.items():
-    #     drive["event_seed"] += net.gid_ranges[drive_name][0]
+    if net._legacy_mode_v2:
+        # in [AES: the original?] HNN-GUI, seed is determined by "absolute GID" instead
+        # of the gid offset with respect to the first cell of a population.
+        for drive_name, drive in net.external_drives.items():
+            drive["event_seed"] += net.gid_ranges[drive_name][0]
 
 
 def _get_prng(seed, gid):

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -356,8 +356,12 @@ class Network:
         for backward-compatibility with HNN GUI, and will be deprecated in a
         future release.
     legacy_mode : bool, default=False
-        Set to True by default to enable matching HNN GUI output when drives
+        Set to False by default to enable matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
+    legacy_mode_v2 : bool, default=False
+        If True, change the behavior of certain parts of the default model so that they
+        do not include several small bug-fixes and changes. Defaults to False. These
+        changes include fixes to how drive seeds are set and synaptic delays.
     mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
     pos_dict : dict of list of tuple (x, y, z), optional
@@ -441,6 +445,7 @@ class Network:
         params,
         add_drives_from_params=False,
         legacy_mode=False,
+        legacy_mode_v2=True,  # AES debug
         mesh_shape=(10, 10),
         pos_dict=None,
         cell_types=None,
@@ -469,6 +474,7 @@ class Network:
                 DeprecationWarning,
                 stacklevel=1,
             )
+        self._legacy_mode_v2 = legacy_mode_v2
 
         self.cell_response = None
         # external drives and biases

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -357,11 +357,14 @@ class Network:
         future release.
     legacy_mode : bool, default=False
         Set to False by default to enable matching HNN GUI output when drives
-        are added suitably. Will be deprecated in a future release.
+        are added suitably. Will be deprecated in a future release. If this is set to
+        True, this automatically enables `legacy_mode_v2`, since `legacy_mode` depends
+        on `legacy_mode_v2` being true.
     legacy_mode_v2 : bool, default=False
         If True, change the behavior of certain parts of the default model so that they
-        do not include several small bug-fixes and changes. Defaults to False. These
-        changes include fixes to how drive seeds are set and synaptic delays.
+        do not include several small bug-fixes and changes. This defaults to False,
+        unless `legacy_mode` is True, in which case it is set to True. These changes
+        include fixes to how drive seeds are set and synaptic delays.
     mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
     pos_dict : dict of list of tuple (x, y, z), optional
@@ -474,6 +477,14 @@ class Network:
                 DeprecationWarning,
                 stacklevel=1,
             )
+
+            # AES: Because `legacy_mode` requires that drives' event seeds (see
+            # https://github.com/jonescompneurolab/hnn-core/blob/90f4d636b13647869f11825daf40eb985b6965cb/hnn_core/params.py#L244
+            # be altered both by the behavior of the `legacy_mode` flag, but also that
+            # drives' event seeds be based on the drives' GIDS. Because
+            # `legacy_mode_v2=False` stops the drives' seeds' dependency on GIDS,
+            # `legacy_mode=True` is dependent on `legacy_mode_v2` being True as well:
+            legacy_mode_v2 = True
         self._legacy_mode_v2 = legacy_mode_v2
 
         self.cell_response = None

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -17,6 +17,7 @@ def jones_2009_model(
     params=None,
     add_drives_from_params=False,
     legacy_mode=False,
+    legacy_mode_v2=True,
     mesh_shape=(10, 10),
 ):
     """Instantiate the network model described in Jones et al. 2009
@@ -34,6 +35,10 @@ def jones_2009_model(
     legacy_mode : bool
         Set to False by default. Enables matching HNN GUI output when drives
         are added suitably. Will be deprecated in a future release.
+    legacy_mode_v2 : bool, default=False
+        If True, change the behavior of certain parts of the default model so that they
+        do not include several small bug-fixes and changes. Defaults to False. These
+        changes include fixes to how drive seeds are set and synaptic delays.
     mesh_shape : tuple of int (default: (10, 10))
         Defines the (n_x, n_y) shape of the grid of pyramidal cells.
 
@@ -140,6 +145,7 @@ def jones_2009_model(
         params,
         add_drives_from_params=add_drives_from_params,
         legacy_mode=legacy_mode,
+        legacy_mode_v2=legacy_mode_v2,
         mesh_shape=mesh_shape,
         pos_dict=pos_dict,
         cell_types=cell_types,
@@ -265,7 +271,11 @@ def jones_2009_model(
 
 
 def law_2021_model(
-    params=None, add_drives_from_params=False, legacy_mode=False, mesh_shape=(10, 10)
+    params=None,
+    add_drives_from_params=False,
+    legacy_mode=False,
+    legacy_mode_v2=True,
+    mesh_shape=(10, 10),
 ):
     """Instantiate the expansion of Jones 2009 model to study beta
     modulated ERPs as described in
@@ -301,7 +311,11 @@ def law_2021_model(
     """
 
     net = jones_2009_model(
-        params, add_drives_from_params, legacy_mode, mesh_shape=mesh_shape
+        params,
+        add_drives_from_params,
+        legacy_mode,
+        legacy_mode_v2=legacy_mode_v2,
+        mesh_shape=mesh_shape,
     )
 
     # Update biophysics (increase gabab duration of inhibition)
@@ -351,7 +365,11 @@ def law_2021_model(
 # Remove params argument after updating examples
 # (only relevant for Jones 2009 model)
 def calcium_model(
-    params=None, add_drives_from_params=False, legacy_mode=False, mesh_shape=(10, 10)
+    params=None,
+    add_drives_from_params=False,
+    legacy_mode=False,
+    legacy_mode_v2=True,
+    mesh_shape=(10, 10),
 ):
     """Instantiate the Jones 2009 model with improved calcium dynamics in
     L5 pyramidal neurons. For more details on changes to calcium dynamics
@@ -387,7 +405,11 @@ def calcium_model(
         params = read_params(params_fname)
 
     net = jones_2009_model(
-        params, add_drives_from_params, legacy_mode, mesh_shape=mesh_shape
+        params,
+        add_drives_from_params,
+        legacy_mode,
+        legacy_mode_v2=legacy_mode_v2,
+        mesh_shape=mesh_shape,
     )
 
     # Replace L5 pyramidal cell template with updated calcium

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -17,7 +17,7 @@ def jones_2009_model(
     params=None,
     add_drives_from_params=False,
     legacy_mode=False,
-    legacy_mode_v2=True,
+    legacy_mode_v2=False,
     mesh_shape=(10, 10),
 ):
     """Instantiate the network model described in Jones et al. 2009

--- a/hnn_core/param/jones2009_base.json
+++ b/hnn_core/param/jones2009_base.json
@@ -6535,7 +6535,7 @@
             "type": "evoked",
             "location": "distal",
             "n_drive_cells": 235,
-            "event_seed": 272,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 63.53,
@@ -6556,7 +6556,7 @@
             "synaptic_delays": {
                 "L2_basket": 0.1,
                 "L2_pyramidal": 0.1,
-                "L5_pyramidal": 0.1
+                "L5_pyramidal": 1.0
             },
             "probability": 1.0,
             "name": "evdist1",
@@ -6571,7 +6571,7 @@
             "type": "evoked",
             "location": "proximal",
             "n_drive_cells": 270,
-            "event_seed": 507,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 26.61,
@@ -6611,7 +6611,7 @@
             "type": "evoked",
             "location": "proximal",
             "n_drive_cells": 270,
-            "event_seed": 777,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 137.12,
@@ -103699,7 +103699,7 @@
             "loc": "distal",
             "receptor": "ampa",
             "nc_dict": {
-                "A_delay": 0.1,
+                "A_delay": 1.0,
                 "A_weight": 0.1423,
                 "lamtha": 3.0,
                 "threshold": 0.0,
@@ -104222,7 +104222,7 @@
             "loc": "distal",
             "receptor": "nmda",
             "nc_dict": {
-                "A_delay": 0.1,
+                "A_delay": 1.0,
                 "A_weight": 0.080074,
                 "lamtha": 3.0,
                 "threshold": 0.0,

--- a/hnn_core/params.py
+++ b/hnn_core/params.py
@@ -159,10 +159,15 @@ def _extract_bias_specs_from_hnn_params(params, cellname_list):
     return bias_specs
 
 
-def _extract_drive_specs_from_hnn_params(params, cellname_list, legacy_mode=False):
+def _extract_drive_specs_from_hnn_params(
+    params,
+    cellname_list,
+    legacy_mode=False,
+    legacy_mode_v2=False,
+):
     """Create 'drive specification' dicts from saved parameters"""
     # convert legacy params-dict to legacy "feeds" dicts
-    p_common, p_unique = create_pext(params, params["tstop"])
+    p_common, p_unique = create_pext(params, params["tstop"], legacy_mode_v2)
 
     # Using 'feed' for legacy compatibility, 'drives' for new API
     drive_specs = dict()
@@ -473,7 +478,7 @@ def check_pois_synkeys(p):
 # creates the external feed params based on individual simulation params p
 
 
-def create_pext(p, tstop):
+def create_pext(p, tstop, legacy_mode_v2):
     """Indexable Python list of param dicts for parallel.
 
     Turn off individual feeds by commenting out relevant line here.
@@ -623,7 +628,7 @@ def create_pext(p, tstop):
             "L5_pyramidal": (
                 p["gbar_" + skey + "_L5Pyr_ampa"],
                 p["gbar_" + skey + "_L5Pyr_nmda"],
-                1.0,
+                1.0 if not legacy_mode_v2 else 0.1,
                 p["sigma_t_" + skey],
             ),
             "L2_basket": (
@@ -649,7 +654,7 @@ def create_pext(p, tstop):
         "L2_basket": (
             p["L2Basket_Gauss_A_weight"],
             p["L2Basket_Gauss_A_weight"],
-            0.1,
+            0.1 if not legacy_mode_v2 else 1.0,
             p["L2Basket_Gauss_mu"],
             p["L2Basket_Gauss_sigma"],
         ),
@@ -689,7 +694,7 @@ def create_pext(p, tstop):
         "L2_basket": (
             p["L2Basket_Pois_A_weight_ampa"],
             p["L2Basket_Pois_A_weight_nmda"],
-            0.1,
+            0.1 if not legacy_mode_v2 else 1.0,
             p["L2Basket_Pois_lamtha"],
         ),
         "L2_pyramidal": (

--- a/hnn_core/tests/assets/jones2009_3x3_drives.json
+++ b/hnn_core/tests/assets/jones2009_3x3_drives.json
@@ -1957,7 +1957,7 @@
             "type": "evoked",
             "location": "distal",
             "n_drive_cells": 21,
-            "event_seed": 26,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 63.53,
@@ -1978,7 +1978,7 @@
             "synaptic_delays": {
                 "L2_basket": 0.1,
                 "L2_pyramidal": 0.1,
-                "L5_pyramidal": 0.1
+                "L5_pyramidal": 1.0
             },
             "probability": 1.0,
             "name": "evdist1",
@@ -1993,7 +1993,7 @@
             "type": "evoked",
             "location": "proximal",
             "n_drive_cells": 24,
-            "event_seed": 47,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 26.61,
@@ -2033,7 +2033,7 @@
             "type": "evoked",
             "location": "proximal",
             "n_drive_cells": 24,
-            "event_seed": 71,
+            "event_seed": 2,
             "conn_seed": 3,
             "dynamics": {
                 "mu": 137.12,
@@ -2459,7 +2459,7 @@
             "loc": "distal",
             "receptor": "ampa",
             "nc_dict": {
-                "A_delay": 0.1,
+                "A_delay": 1.0,
                 "A_weight": 0.1423,
                 "lamtha": 3.0,
                 "threshold": 0.0,
@@ -2527,7 +2527,7 @@
             "loc": "distal",
             "receptor": "nmda",
             "nc_dict": {
-                "A_delay": 0.1,
+                "A_delay": 1.0,
                 "A_weight": 0.080074,
                 "lamtha": 3.0,
                 "threshold": 0.0,


### PR DESCRIPTION
This adds usage of a new flag to `Network` named `legacy_mode_v2`. This is intended as a compatibility flag that is distinct from the existing `legacy_mode`. When true, this new flag uses the old `drive["event_seed"]` behavior and the old synaptic delays.

I've thought about this and tried a couple of different ways to approach this problem, and this makes the most sense to me. Doing it this way is ugly, yes, but:
1. Backwards-compatibility is more important in scientific code than usual. Adding various flags to support this is a small price to pay; the cyclomatic complexities of the affected functions are already very high quite frankly, but keeping the old logic around helps with reproducibility.
2. Specifying more legacy flags is ugly, yes, but it also allows us to heavily document what the *differences* between those versions are.
3. Doing it this way allows for a user to use different combinations of different legacy modes. I initially tried changing `legacy_mode` to an integer in order to turn it into a kind of "version", but then I realized that this means the "versions" would be mutually exclusive, which is bad. It is possible that someone will want to use all the available legacy versions.
4. I think this is a forward-compatible solution as well. As long as we are documenting everything well, this allows us to apply updates that impact the *actual scientific output* of our default model (instead of just file formats, etc.).

Note: for debug reasons, this flag is currently set to TRUE. But that's just because I want to package this commit separately from the required updates to the tests that this needs.

This is incomplete, since I still need to fix the tests that are broken when the flag is off, and we need to discuss whether this is how we want to move forward.