### PR TITLE
Kd merge master metadata

### DIFF
--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -27,6 +27,7 @@ from ipywidgets import (
 
 from hnn_core.dipole import _anticorr, _rmse, average_dipoles
 from hnn_core.gui._logging import logger
+from hnn_core.network_models import default_drive_colors
 from hnn_core.viz import plot_dipole, plot_tfr_morlet
 
 #
@@ -298,18 +299,19 @@ def _update_ax(fig, ax, single_simulation, sim_name, plot_type, plot_config):
                 if "evdist" in name:
                     if "evdist" not in drive_locations.keys():
                         drive_locations["evdist"] = drive["location"]
-                        drive_colors["evdist"] = "g"
+                        drive_colors["evdist"] = default_drive_colors["distal"]
                 # remove all increments of default 'evprox' inputs
                 elif "evprox" in name:
                     if "evprox" not in drive_locations.keys():
                         drive_locations["evprox"] = drive["location"]
-                        drive_colors["evprox"] = "r"
+                        drive_colors["evprox"] = default_drive_colors["proximal"]
+
                 else:
                     drive_locations[name] = drive["location"]
                     if drive["location"] == "proximal":
-                        drive_colors[name] = "r"
+                        drive_colors[name] = default_drive_colors["proximal"]
                     elif drive["location"] == "distal":
-                        drive_colors[name] = "g"
+                        drive_colors[name] = default_drive_colors["distal"]
 
             # all drives to plot, excluding 'evdist' and 'evprox' increments
             all_drives = list(drive_locations.keys())

--- a/hnn_core/network.py
+++ b/hnn_core/network.py
@@ -559,46 +559,24 @@ class Network:
 
         else:
             # Default behavior - create standard network
+            from .network_models import default_cell_metadata
+
             cell_types_default = {
                 "L2_basket": {
                     "cell_object": basket(cell_name="L2_basket"),
-                    "cell_metadata": {
-                        "morpho_type": "basket",
-                        "electro_type": "inhibitory",
-                        "layer": "2",
-                        "measure_dipole": False,
-                        "reference": "https://doi.org/10.7554/eLife.51214",
-                    },
+                    "cell_metadata": deepcopy(default_cell_metadata["L2_basket"]),
                 },
                 "L2_pyramidal": {
                     "cell_object": pyramidal(cell_name="L2_pyramidal"),
-                    "cell_metadata": {
-                        "morpho_type": "pyramidal",
-                        "electro_type": "excitatory",
-                        "layer": "2",
-                        "measure_dipole": True,
-                        "reference": "https://doi.org/10.7554/eLife.51214",
-                    },
+                    "cell_metadata": deepcopy(default_cell_metadata["L2_pyramidal"]),
                 },
                 "L5_basket": {
                     "cell_object": basket(cell_name="L5_basket"),
-                    "cell_metadata": {
-                        "morpho_type": "basket",
-                        "electro_type": "inhibitory",
-                        "layer": "5",
-                        "measure_dipole": False,
-                        "reference": "https://doi.org/10.7554/eLife.51214",
-                    },
+                    "cell_metadata": deepcopy(default_cell_metadata["L5_basket"]),
                 },
                 "L5_pyramidal": {
                     "cell_object": pyramidal(cell_name="L5_pyramidal"),
-                    "cell_metadata": {
-                        "morpho_type": "pyramidal",
-                        "electro_type": "excitatory",
-                        "layer": "5",
-                        "measure_dipole": True,
-                        "reference": "https://doi.org/10.7554/eLife.51214",
-                    },
+                    "cell_metadata": deepcopy(default_cell_metadata["L5_pyramidal"]),
                 },
             }
 

--- a/hnn_core/network_models.py
+++ b/hnn_core/network_models.py
@@ -3,6 +3,7 @@
 # Authors: Nick Tolley <nicholas_tolley@brown.edu>
 
 import os.path as op
+from copy import deepcopy
 import warnings
 
 import hnn_core
@@ -18,6 +19,107 @@ from .cells_default import (
     interneuron,
 )
 from .externals.mne import _validate_type
+
+# Default cell metadata for the standard Jones 2009 network cell types.
+# Defined here at module level so that other code (e.g. JSON
+# serialisation / deserialisation) can import it without instantiating
+# a full Network object.
+
+default_cell_metadata = {
+    "L2_basket": {
+        "morpho_type": "basket",
+        "electro_type": "inhibitory",
+        "layer": "2",
+        "zdist_origin": 0.8,  # distance to origin in percent of layer_separation
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "m",
+        "marker": "x",  # shape from prev viz.py line:926
+    },
+    "L2_pyramidal": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "2",
+        "zdist_origin": 1,
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "c",
+        "marker": "^",
+    },
+    "L5_basket": {
+        "morpho_type": "basket",
+        "electro_type": "inhibitory",
+        "layer": "5",
+        "zdist_origin": 0.2,
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "r",
+        "marker": "x",
+    },
+    "L5_pyramidal": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "5",
+        "zdist_origin": 0,
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "b",
+        "marker": "^",
+    },
+}
+
+default_drive_colors = {
+    "proximal": "r",
+    "distal": "g",
+    "default": "#8B4513",
+}
+
+# Cell metadata for the new Duecker model network cell types.
+duecker_cell_metadata = {
+    "L2_basket": {
+        "morpho_type": "interneuron",
+        "electro_type": "inhibitory",
+        "layer": "2",
+        "zdist_origin": 0.8,
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "m",
+        "marker": "x",
+    },
+    "L2_pyramidal": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "2",
+        "zdist_origin": 1,
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "c",
+        "marker": "^",
+    },
+    "L5_basket": {
+        "morpho_type": "interneuron",
+        "electro_type": "inhibitory",
+        "layer": "5",
+        "zdist_origin": 0.2,
+        "measure_dipole": False,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "r",
+        "marker": "x",
+    },
+    "L5ET": {
+        "morpho_type": "pyramidal",
+        "electro_type": "excitatory",
+        "layer": "5",
+        "zdist_origin": 0,
+        "measure_dipole": True,
+        "reference": "https://doi.org/10.7554/eLife.51214",
+        "color": "b",
+        "marker": "^",
+    },
+}
+
+
+# ToDO -> direct _cell_L2Pyr calling
 
 
 def neymotin_2020_model(
@@ -85,47 +187,19 @@ def neymotin_2020_model(
     cell_types = {
         "L2_basket": {
             "cell_object": basket(cell_name="L2_basket"),
-            "cell_metadata": {
-                "morpho_type": "basket",
-                "electro_type": "inhibitory",
-                "layer": "2",
-                "zdist_origin": 0.8,  # distance to origin in percent of layer_separation
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(default_cell_metadata["L2_basket"]),
         },
         "L2_pyramidal": {
             "cell_object": pyramidal(cell_name="L2_pyramidal"),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "2",
-                "zdist_origin": 1,
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(default_cell_metadata["L2_pyramidal"]),
         },
         "L5_basket": {
             "cell_object": basket(cell_name="L5_basket"),
-            "cell_metadata": {
-                "morpho_type": "basket",
-                "electro_type": "inhibitory",
-                "layer": "5",
-                "zdist_origin": 0.2,
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(default_cell_metadata["L5_basket"]),
         },
         "L5_pyramidal": {
             "cell_object": pyramidal(cell_name="L5_pyramidal"),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "5",
-                "zdist_origin": 0,
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(default_cell_metadata["L5_pyramidal"]),
         },
     }
 
@@ -507,47 +581,19 @@ def duecker_ET_model(
     cell_types = {
         "L2_basket": {
             "cell_object": interneuron(cell_name=_short_name("L2_basket"), layer=2),
-            "cell_metadata": {
-                "morpho_type": "interneuron",
-                "electro_type": "inhibitory",
-                "layer": "2",
-                "zdist_origin": 0.8,
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(duecker_cell_metadata["L2_basket"]),
         },
         "L2_pyramidal": {
             "cell_object": pyramidal_l23(cell_name=_short_name("L2_pyramidal")),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "2",
-                "zdist_origin": 1,
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(duecker_cell_metadata["L2_pyramidal"]),
         },
         "L5_basket": {
             "cell_object": interneuron(cell_name=_short_name("L5_basket"), layer=5),
-            "cell_metadata": {
-                "morpho_type": "interneuron",
-                "electro_type": "inhibitory",
-                "layer": "5",
-                "zdist_origin": 0.2,
-                "measure_dipole": False,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(duecker_cell_metadata["L5_basket"]),
         },
         "L5ET": {
             "cell_object": pyramidal_l5ET(cell_name="L5ET"),
-            "cell_metadata": {
-                "morpho_type": "pyramidal",
-                "electro_type": "excitatory",
-                "layer": "5",
-                "zdist_origin": 0,
-                "measure_dipole": True,
-                "reference": "https://doi.org/10.7554/eLife.51214",
-            },
+            "cell_metadata": deepcopy(duecker_cell_metadata["L5ET"]),
         },
     }
 

--- a/hnn_core/param/neymotin2020_base.json
+++ b/hnn_core/param/neymotin2020_base.json
@@ -85,7 +85,9 @@
                 "layer": "2",
                 "zdist_origin": 0.8,
                 "measure_dipole": false,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "m",
+                "marker": "x"
             }
         },
         "L2_pyramidal": {
@@ -482,7 +484,9 @@
                 "layer": "2",
                 "zdist_origin": 1,
                 "measure_dipole": true,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "c",
+                "marker": "^"
             }
         },
         "L5_basket": {
@@ -563,7 +567,9 @@
                 "layer": "5",
                 "zdist_origin": 0.2,
                 "measure_dipole": false,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "r",
+                "marker": "x"
             }
         },
         "L5_pyramidal": {
@@ -1286,7 +1292,9 @@
                 "layer": "5",
                 "zdist_origin": 0,
                 "measure_dipole": true,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "b",
+                "marker": "^"
             }
         }
     },

--- a/hnn_core/tests/assets/neymotin2020_3x3_drives.json
+++ b/hnn_core/tests/assets/neymotin2020_3x3_drives.json
@@ -85,7 +85,9 @@
                 "layer": "2",
                 "zdist_origin": 0.8,
                 "measure_dipole": false,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "m",
+                "marker": "x"
             }
         },
         "L2_pyramidal": {
@@ -482,7 +484,9 @@
                 "layer": "2",
                 "zdist_origin": 1,
                 "measure_dipole": true,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "c",
+                "marker": "^"
             }
         },
         "L5_basket": {
@@ -563,7 +567,9 @@
                 "layer": "5",
                 "zdist_origin": 0.2,
                 "measure_dipole": false,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "r",
+                "marker": "x"
             }
         },
         "L5_pyramidal": {
@@ -1286,7 +1292,9 @@
                 "layer": "5",
                 "zdist_origin": 0,
                 "measure_dipole": true,
-                "reference": "https://doi.org/10.7554/eLife.51214"
+                "reference": "https://doi.org/10.7554/eLife.51214",
+                "color": "b",
+                "marker": "^"
             }
         }
     },

--- a/hnn_core/tests/test_viz.py
+++ b/hnn_core/tests/test_viz.py
@@ -11,6 +11,8 @@ import pytest
 
 import hnn_core
 from hnn_core import read_params, neymotin_2020_model
+from hnn_core.dipole import simulate_dipole
+from hnn_core.network_models import default_cell_metadata
 from hnn_core.viz import (
     plot_cells,
     plot_dipole,
@@ -21,7 +23,6 @@ from hnn_core.viz import (
     plot_drive_strength,
     NetworkPlotter,
 )
-from hnn_core.dipole import simulate_dipole
 
 matplotlib.use("agg")
 
@@ -399,13 +400,16 @@ class TestCellResponsePlotters:
             labels = [text.get_text() for text in fig.axes[0].legend_.get_texts()]
             return colors, labels
 
-        # Default colors should be the default color cycle
+        # Default colors should come from cell metadata
         fig = net.cell_response.plot_spikes_raster(trial_idx=0, show=False)
-        colors, _ = _get_line_hex_colors(fig)
-        default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"][
-            0 : len(colors)
+        colors, labels = _get_line_hex_colors(fig)
+
+        expected_cell_types = sorted(default_cell_metadata.keys())
+        expected_colors = [
+            matplotlib.colors.to_hex(default_cell_metadata[ct]["color"])
+            for ct in expected_cell_types
         ]
-        assert colors == default_colors
+        assert colors == expected_colors
 
         # Custom hex colors as list
         custom_colors = ["#daf7a6", "#ffc300", "#ff5733", "#c70039"]

--- a/hnn_core/viz.py
+++ b/hnn_core/viz.py
@@ -24,6 +24,27 @@ from scipy.signal import decimate, periodogram
 from .externals.mne import tfr_array_morlet, _validate_type
 
 
+def _get_cell_colors_from_metadata(cell_types_dict):
+    """Get color and marker mappings from cell_metadata.
+
+    Parameters
+    ----------
+    cell_types_dict : dict
+
+    Returns
+    -------
+    colors : dict
+    markers : dict
+    """
+    colors = dict()
+    markers = dict()
+    for cell_name in sorted(cell_types_dict.keys()):
+        meta = cell_types_dict[cell_name].get("cell_metadata", {})
+        colors[cell_name] = meta.get("color", "k")
+        markers[cell_name] = meta.get("marker", "o")
+    return colors, markers
+
+
 def _lighten_color(color, amount=0.5):
     try:
         c = matplotlib.colors.cnames[color]
@@ -487,7 +508,15 @@ def plot_spikes_hist(
     spike_types_mask = {
         s_type: np.isin(spike_types_data, s_type) for s_type in unique_types
     }
-    cell_types = cell_response._cell_type_names
+    # fetching the cell types
+    # TODO KD the Duecker model now requires us to import duecker_cell_metadata AND use
+    # a NEW attribute (which we need to create) inside CellResponse that indicates what
+    # the name of the model used to create CellResponse was. That way, we can specify
+    # which variant of metadata to use.
+    from .network_models import default_cell_metadata
+
+    known_cell_types = set(default_cell_metadata.keys())
+    cell_types = sorted([ct for ct in unique_types if ct in known_cell_types])
     input_types = np.setdiff1d(unique_types, cell_types)
 
     if isinstance(spike_types, str):
@@ -552,6 +581,12 @@ def plot_spikes_hist(
         spike_label: list() for spike_label in np.unique(list(spike_labels.values()))
     }
     spike_color = dict()  # Store colors specified for each spike_label
+    # NOTE: Currently, since `CellResponse` only contains the "type" (aka drive name or
+    # cell name) of what produced each spike, but not whether that drive was proximal or
+    # distal, there is currently no way to apply the coloring of
+    # `hnn_core.network_models.default_drive_colors` to the spikes in this plot. If
+    # `CellResponse` is ever guaranteed access to the `Network` information in the
+    # future, then this will be fixable.
     for spike_type, spike_label in spike_labels.items():
         if spike_label not in spike_color:
             if isinstance(color, dict):
@@ -563,6 +598,9 @@ def plot_spikes_hist(
                     color[spike_label], str, "Dictionary values of color", "str"
                 )
                 spike_color[spike_label] = color[spike_label]
+            elif spike_label in default_cell_metadata.keys():
+                # Overwrite spike colors if the spikes come from true cells
+                spike_color[spike_label] = default_cell_metadata[spike_label]["color"]
             else:
                 spike_color[spike_label] = next(color_cycle)
         spike_type_times[spike_label].extend(spike_times[spike_types_mask[spike_type]])
@@ -713,14 +751,21 @@ def plot_spikes_raster(
                 f"Got {cell_types}"
             )
     else:
-        # Use all cell types and warn user that they should select cell types
-        cell_types = cell_response._cell_type_names
+        # TODO KD the Duecker model now requires us to import duecker_cell_metadata AND use
+        # a NEW attribute (which we need to create) inside CellResponse that indicates what
+        # the name of the model used to create CellResponse was. That way, we can specify
+        # which variant of metadata to use.
+        from .network_models import default_cell_metadata
 
-    # Set default colors
-    default_colors = plt.rcParams["axes.prop_cycle"].by_key()["color"][
-        : len(cell_types)
-    ]
-    cell_colors = {cell: color for cell, color in zip(cell_types, default_colors)}
+        known_cell_types = set(default_cell_metadata.keys())
+        cell_types = sorted([ct for ct in unique_spike_types if ct in known_cell_types])
+        if not cell_types:
+            cell_types = sorted(list(known_cell_types))
+
+    # default colors from cell metadata
+    from .network_models import default_cell_metadata as _meta
+
+    cell_colors = {cell: _meta.get(cell, {}).get("color", "k") for cell in cell_types}
 
     # validate colors argument
     _validate_type(colors, (list, dict, None), "color", "list of str, or dict")
@@ -932,32 +977,14 @@ def plot_cells(net, ax=None, show=True, colors=None, markers=None):
             f"Expected 'ax' to be an instance of Axes3D, but got {type(ax).__name__}"
         )
 
-    if colors is None:
-        color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-        colors = {
-            cell_type: color_cycle[i % len(color_cycle)]
-            for i, cell_type in enumerate(net.cell_types)
-        }
+    # colors and markers from cell metadata
+    if net.cell_types:
+        colors, markers = _get_cell_colors_from_metadata(net.cell_types)
+    else:
+        colors = dict()
+        markers = dict()
 
-    if markers is None:
-        morpho_marker_map = {"pyramidal": "^", "basket": "x", "interneuron": "o"}
-        all_markers = ["^", "x", "o", "s", "D", "P", "*", "v", "<", ">"]
-        used_markers = set(morpho_marker_map.values())
-        markers = {}
-        for cell_type in net.cell_types:
-            morpho_type = net.cell_types[cell_type]["cell_metadata"].get(
-                "morpho_type", ""
-            )
-            if morpho_type in morpho_marker_map:
-                markers[cell_type] = morpho_marker_map[morpho_type]
-            else:
-                for m in all_markers:
-                    if m not in used_markers:
-                        markers[cell_type] = m
-                        used_markers.add(m)
-                        break
-
-    for cell_type in net.cell_types:
+    for cell_type in sorted(net.cell_types.keys()):
         x = [pos[0] for pos in net.pos_dict[cell_type]]
         y = [pos[1] for pos in net.pos_dict[cell_type]]
         z = [pos[2] for pos in net.pos_dict[cell_type]]


### PR DESCRIPTION
@katduecker This merges Chetan's improved metadata handling from master into the
Duecker model branch. The main updates are in `network_models.py` which
updated cleanly, and `viz.py` which did not.

There is now a new TODO: because several of the plotting functions only
take CellResponse with no network, but we want to reuse the metadata for
that model without CellResponse having a copy of the network, this means
that we need to add a new attribute to CellResponse that specifies WHICH
model was used to create CellResponse. (In the future we will refactor
both CellResponse and the appropriate plotting functions to use its
founding network directly, but today is NOT that day.)
